### PR TITLE
Allow custom line breaks on display text

### DIFF
--- a/src/ColorWallpaper.py
+++ b/src/ColorWallpaper.py
@@ -70,7 +70,8 @@ class Wallpaper:
         texts = [[]]
         max_text_length = 0
         text_length = -first_glyph_whitespace
-        words = text.split(" ")
+        LINE_BREAK = "\\n"
+        words = text.replace(LINE_BREAK, f" {LINE_BREAK} ").split(" ")
 
         while words:
             next_word = words.pop(0)
@@ -81,7 +82,10 @@ class Wallpaper:
                 words = Wallpaper.__split_word(next_word) + words
                 continue
 
-            if text_length + next_word_length <= 112:
+            if next_word == LINE_BREAK:
+                texts.append([])
+                text_length = -first_glyph_whitespace
+            elif text_length + next_word_length <= 112:
                 texts[-1].append(next_word)
                 text_length += next_word_length
             else:
@@ -158,7 +162,7 @@ class Wallpaper:
                 ignored = len(self.formats) - i
                 if ignored:
                     print(
-                        f"Too many formats specified. "
+                        f"Text too long or too many formats specified. "
                         f"Ignoring {ignored} format{'' if ignored == 1 else 's'}: "
                         f"{', '.join(self.formats[i:])}",
                         file=sys.stderr,


### PR DESCRIPTION
Description
-----------
There was no way to add line breaks to a custom display name. This commit solves this by transforming explicit newline characters (line feed, to be more precise) into "real" line breaks when creating the wallpaper.

Sample usage
------------
> `python src/ColorWallpaper.py -f empty -d "A\nText\nSplitted\nOver\nMany\nLines!"`

Implementation details
----------------------
Not too much thought was put into this, the code just literally searches for the "\n" character and transforms it. Also, no automated test was added.

Possible bugs
-------------
- Pressing the return key instead of putting literal newline characters might have an unexpected behavior;
- The bottom part of the text won't show up if the text is too big vertically (and no warnings or errors will appear).